### PR TITLE
Fix typo in setOtherTaxesPercentCategory()

### DIFF
--- a/src/Models/InvoiceRowType.php
+++ b/src/Models/InvoiceRowType.php
@@ -392,7 +392,7 @@ class InvoiceRowType extends Type
      */
     public function setOtherTaxesPercentCategory(int $otherTaxesPercentCategory): self
     {
-        return $this->put('feesPercentCategory', $otherTaxesPercentCategory);
+        return $this->put('otherTaxesPercentCategory', $otherTaxesPercentCategory);
     }
 
     /**


### PR DESCRIPTION
Καλησπέρα,
Υπάρχει ένα typo στην συνάρτηση ```setOtherTaxesPercentCategory()``` . Το πρώτο argument της put είναι ```'feesPercentCategory'``` ενώ θα έπρεπε να είναι ```'otherTaxesPercentCategory'```.