### PR TITLE
Ensure simple values do not throw an exception.

### DIFF
--- a/src/Parser/InvoicesDocXML.php
+++ b/src/Parser/InvoicesDocXML.php
@@ -63,8 +63,12 @@ class InvoicesDocXML
             }
 
             foreach ($property as $value) {
-                $child = $this->addNode($xml, $this->getTypeName($value));
-                $this->toXML($child, $value);
+                if ($value instanceof Type) {
+                    $child = $this->addNode($xml, $this->getTypeName($value));
+                    $this->toXML($child, $value);
+                    continue;
+                }
+                $this->addNode($xml, $key, $value, $type);
             }
         }
     }


### PR DESCRIPTION
 There is a small bug when you try to insert a correlated invoice to the invoice header and send the request.
 The correlated invoice is stored as an array of int marks, and the check at the parser InvoicesDocXML::toXMl() triggers an error because `$this->getTypeName($value)` checks for an object of class Type but array is given for correlated invoices.

    if (!is_array($property)) {
        $this->addNode($xml, $key, $property, $type);
        continue;
    }

    foreach ($property as $value) {
        $child = $this->addNode($xml, $this->getTypeName($value));
        $this->toXML($child, $value);
    }
}`

### Step to reproduce ### 
- Create a valid invoice with proper valid values `$invoice = new Invoice()` and set all necessary objects for the invoice. Header, issuer, counterpart etc.
- Add a correlated invoice mark inside the invoice header `($invoiceHeader->addCorrelatedInvoice(int $mark))`.
- After the invoice is created, send a test request to aade  `($invoice->handle(SendInvoices::class))`.

### Proposed solution ### 

Either create a class for the correlated invoices that extends the Type or add an extra check for values that don't extend the Type base class.