### PR TITLE
Fix empty XML response and Model Type

### DIFF
--- a/src/Actions/SummarizeInvoiceRows.php
+++ b/src/Actions/SummarizeInvoiceRows.php
@@ -42,12 +42,12 @@ class SummarizeInvoiceRows
 
         $this->saveTaxes($summary);
 
-        $grossValue = $this->round($this->getTotalGrossValue());
+        $grossValue = $this->getTotalGrossValue();
         $summary->setTotalGrossValue($grossValue);
     }
 
     public function getTotalGrossValue(): float
     {
-        return $this->totalNetValue + $this->totalVatAmount + $this->getTotalTaxes();
+        return $this->round($this->totalNetValue + $this->totalVatAmount + $this->getTotalTaxes());
     }
 }

--- a/src/Actions/Traits/SummarizesInvoiceTaxes.php
+++ b/src/Actions/Traits/SummarizesInvoiceTaxes.php
@@ -66,7 +66,7 @@ trait SummarizesInvoiceTaxes
         $this->updateTaxAmount($summary, 'TotalStampDutyAmount', $this->totalStampDutyAmount);
         $this->updateTaxAmount($summary, 'TotalOtherTaxesAmount', $this->totalOtherTaxesAmount);
         $this->updateTaxAmount($summary, 'TotalDeductionsAmount', $this->totalDeductionsAmount);
-        $this->updateTaxAmount($summary, 'TotalInformationalTaxAmount', $this->totalInformationTaxAmount);
+        $this->updateTaxAmount($summary, 'TotalInformationTaxAmount', $this->totalInformationTaxAmount);
     }
 
     /**

--- a/src/Actions/Traits/SummarizesInvoiceTaxes.php
+++ b/src/Actions/Traits/SummarizesInvoiceTaxes.php
@@ -2,7 +2,7 @@
 
 namespace Firebed\AadeMyData\Actions\Traits;
 
-use Firebed\AadeMyData\Enums\TaxType;
+use Firebed\AadeMyData\Enums\TaxType; 
 use Firebed\AadeMyData\Enums\WithheldPercentCategory;
 use Firebed\AadeMyData\Models\InvoiceDetails;
 use Firebed\AadeMyData\Models\InvoiceSummary;

--- a/src/Actions/Traits/SummarizesInvoiceTaxes.php
+++ b/src/Actions/Traits/SummarizesInvoiceTaxes.php
@@ -66,7 +66,7 @@ trait SummarizesInvoiceTaxes
         $this->updateTaxAmount($summary, 'TotalStampDutyAmount', $this->totalStampDutyAmount);
         $this->updateTaxAmount($summary, 'TotalOtherTaxesAmount', $this->totalOtherTaxesAmount);
         $this->updateTaxAmount($summary, 'TotalDeductionsAmount', $this->totalDeductionsAmount);
-        $this->updateTaxAmount($summary, 'TotalInformationTaxAmount', $this->totalInformationTaxAmount);
+        $this->updateTaxAmount($summary, 'TotalInformationalTaxAmount', $this->totalInformationTaxAmount);
     }
 
     /**

--- a/src/Actions/Traits/SummarizesInvoiceTaxes.php
+++ b/src/Actions/Traits/SummarizesInvoiceTaxes.php
@@ -61,23 +61,22 @@ trait SummarizesInvoiceTaxes
 
     protected function saveTaxes(InvoiceSummary $summary): void
     {
-        $withheldAmount = $this->round($summary->getTotalWithheldAmount() + $this->totalWithheldAmount);
-        $summary->setTotalWithheldAmount($withheldAmount);
+        $this->updateTaxAmount($summary, 'TotalWithheldAmount', $this->totalWithheldAmount);
+        $this->updateTaxAmount($summary, 'TotalFeesAmount', $this->totalFeesAmount);
+        $this->updateTaxAmount($summary, 'TotalStampDutyAmount', $this->totalStampDutyAmount);
+        $this->updateTaxAmount($summary, 'TotalOtherTaxesAmount', $this->totalOtherTaxesAmount);
+        $this->updateTaxAmount($summary, 'TotalDeductionsAmount', $this->totalDeductionsAmount);
+        $this->updateTaxAmount($summary, 'TotalInformationalTaxAmount', $this->totalInformationTaxAmount);
+    }
 
-        $feesAmount = $this->round($summary->getTotalFeesAmount() + $this->totalFeesAmount);
-        $summary->setTotalFeesAmount($feesAmount);
-
-        $stampDutyAmount = $this->round($summary->getTotalStampDutyAmount() + $this->totalStampDutyAmount);
-        $summary->setTotalStampDutyAmount($stampDutyAmount);
-
-        $otherTaxesAmount = $this->round($summary->getTotalOtherTaxesAmount() + $this->totalOtherTaxesAmount);
-        $summary->setTotalOtherTaxesAmount($otherTaxesAmount);
-
-        $deductionsAmount = $this->round($summary->getTotalDeductionsAmount() + $this->totalDeductionsAmount);
-        $summary->setTotalDeductionsAmount($deductionsAmount);
+    /**
+     * Ενημέρωση των ποσών φόρων στο τιμολόγιο
+     */
+    private function updateTaxAmount(InvoiceSummary $summary, string $methodName, float $amount): void
+    {
+        $currentValue = $summary->{'get'.$methodName}();
+        $summary->{'set'.$methodName}($this->round($currentValue + $amount));
         
-        $informationalTaxes = $this->round($summary->getTotalInformationalTaxAmount() + $this->totalInformationTaxAmount);
-        $summary->setTotalInformationTaxAmount($informationalTaxes);
     }
 
     public function getTotalTaxes(): float

--- a/src/Exceptions/InvalidResponseException.php
+++ b/src/Exceptions/InvalidResponseException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Firebed\AadeMyData\Exceptions;
+
+class InvalidResponseException extends MyDataException
+{
+
+}

--- a/src/Http/CancelInvoice.php
+++ b/src/Http/CancelInvoice.php
@@ -41,10 +41,6 @@ class CancelInvoice extends MyDataRequest
         // Get the response XML
         $responseXML = $this->post($query)->getBody()->getContents();
 
-        if (empty($responseXML)) {
-            throw new MyDataException('Invalid response from MyData API');
-        }
-
         // Parse the response XML
         $reader = new ResponseDocReader();
         $responseDoc = $reader->parseXML($responseXML);

--- a/src/Http/CancelInvoice.php
+++ b/src/Http/CancelInvoice.php
@@ -39,8 +39,11 @@ class CancelInvoice extends MyDataRequest
         }
 
         // Get the response XML
-        $results = $this->post($query);
-        $responseXML = $results->getBody()->getContents();
+        $responseXML = $this->post($query)->getBody()->getContents();
+
+        if (empty($responseXML)) {
+            throw new MyDataException('Invalid response from MyData API');
+        }
 
         // Parse the response XML
         $reader = new ResponseDocReader();

--- a/src/Http/MyDataGetRequest.php
+++ b/src/Http/MyDataGetRequest.php
@@ -66,10 +66,6 @@ abstract class MyDataGetRequest extends MyDataRequest
         // Get the response XML / Ανάκτηση του XML απόκρισης
         $responseXML = $this->get($query)->getBody()->getContents();
         
-        if (empty($responseXML)) {
-            throw new MyDataException('Invalid response from MyData API');
-        }
-
         // Parse the response XML
         $reader = new RequestedDocReader();
         $responseDoc = $reader->parseXML($responseXML);

--- a/src/Http/MyDataGetRequest.php
+++ b/src/Http/MyDataGetRequest.php
@@ -65,6 +65,10 @@ abstract class MyDataGetRequest extends MyDataRequest
 
         // Get the response XML / Ανάκτηση του XML απόκρισης
         $responseXML = $this->get($query)->getBody()->getContents();
+        
+        if (empty($responseXML)) {
+            throw new MyDataException('Invalid response from MyData API');
+        }
 
         // Parse the response XML
         $reader = new RequestedDocReader();

--- a/src/Http/MyDataRequest.php
+++ b/src/Http/MyDataRequest.php
@@ -7,6 +7,7 @@ use Firebed\AadeMyData\Exceptions\MyDataConnectionException;
 use Firebed\AadeMyData\Exceptions\MyDataException;
 use Firebed\AadeMyData\Exceptions\RateLimitExceededException;
 use Firebed\AadeMyData\Exceptions\TransmissionFailedException;
+use Firebed\AadeMyData\Exceptions\InvalidResponseException;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Handler\MockHandler;
@@ -145,7 +146,16 @@ abstract class MyDataRequest
         self::validateCredentials();
 
         try {
-            return $this->client()->get($this->getUrl(), ['query' => $query]);
+
+            $reponse  = $this->client()->get($this->getUrl(), ['query' => $query]);
+
+            if (empty(trim($reponse))) {
+                throw new InvalidResponseException('Invalid response from MyData API');
+        
+            }
+
+
+            return $reponse;
         } catch (GuzzleException $e) {
             $this->handleTransmissionException($e);
         }
@@ -168,7 +178,15 @@ abstract class MyDataRequest
         }
 
         try {
-            return $this->client()->post($this->getUrl(), $params);
+
+            $reponse  = $this->client()->post($this->getUrl(), $params);
+
+            if (empty(trim($reponse))) {
+                throw new InvalidResponseException('Invalid response from MyData API');
+        
+            }
+
+            return $reponse ;
         } catch (GuzzleException $e) {
             $this->handleTransmissionException($e);
         }

--- a/src/Http/MyDataRequest.php
+++ b/src/Http/MyDataRequest.php
@@ -147,7 +147,7 @@ abstract class MyDataRequest
 
         try {
 
-            $reponse  = $this->client()->get($this->getUrl(), ['query' => $query]);
+            $response  = $this->client()->get($this->getUrl(), ['query' => $query]);
 
             $responseBody = (string) $response->getBody();             
 
@@ -157,7 +157,7 @@ abstract class MyDataRequest
             }
 
 
-            return $reponse;
+            return $response;
         } catch (GuzzleException $e) {
             $this->handleTransmissionException($e);
         }
@@ -181,7 +181,7 @@ abstract class MyDataRequest
 
         try {
 
-            $reponse  = $this->client()->post($this->getUrl(), $params);
+            $response  = $this->client()->post($this->getUrl(), $params);
 
             $responseBody = (string) $response->getBody();             
 
@@ -190,7 +190,7 @@ abstract class MyDataRequest
         
             }
 
-            return $reponse ;
+            return $response ;
         } catch (GuzzleException $e) {
             $this->handleTransmissionException($e);
         }

--- a/src/Http/MyDataRequest.php
+++ b/src/Http/MyDataRequest.php
@@ -149,7 +149,9 @@ abstract class MyDataRequest
 
             $reponse  = $this->client()->get($this->getUrl(), ['query' => $query]);
 
-            if (empty(trim($reponse))) {
+            $responseBody = (string) $response->getBody();             
+
+            if (empty(trim($responseBody))) {
                 throw new InvalidResponseException('Invalid response from MyData API');
         
             }
@@ -181,7 +183,9 @@ abstract class MyDataRequest
 
             $reponse  = $this->client()->post($this->getUrl(), $params);
 
-            if (empty(trim($reponse))) {
+            $responseBody = (string) $response->getBody();             
+
+            if (empty(trim($responseBody))) {
                 throw new InvalidResponseException('Invalid response from MyData API');
         
             }

--- a/src/Http/MyDataRequest.php
+++ b/src/Http/MyDataRequest.php
@@ -147,17 +147,24 @@ abstract class MyDataRequest
 
         try {
 
-            $response  = $this->client()->get($this->getUrl(), ['query' => $query]);
+            // Make the request to the API
+            $response = $this->client()->get($this->getUrl(), ['query' => $query]);
 
-            $responseBody = (string) $response->getBody();             
+            // Get the response body stream
+            $stream = $response->getBody();
 
-            if (empty(trim($responseBody))) {
-                throw new InvalidResponseException('Invalid response from MyData API');
-        
-            }
+            // Store the response body contents once in a variable
+            $responseBody = $stream->getContents(); 
 
+            // Rewind the stream so it can be reused if necessary
+            $stream->rewind();
 
-            return $response;
+        // Check if the response body is empty or null
+        if ($response === null || empty(trim($responseBody))) {
+            throw new InvalidResponseException('Invalid or empty response from MyData API');
+        }
+
+        return $response;
         } catch (GuzzleException $e) {
             $this->handleTransmissionException($e);
         }
@@ -183,12 +190,19 @@ abstract class MyDataRequest
 
             $response  = $this->client()->post($this->getUrl(), $params);
 
-            $responseBody = (string) $response->getBody();             
+             // Get the response body stream
+             $stream = $response->getBody();
 
-            if (empty(trim($responseBody))) {
-                throw new InvalidResponseException('Invalid response from MyData API');
-        
-            }
+             // Store the response body contents once in a variable
+             $responseBody = $stream->getContents(); 
+ 
+             // Rewind the stream so it can be reused if necessary
+             $stream->rewind();
+ 
+         // Check if the response body is empty or null
+         if ($response === null || empty(trim($responseBody))) {
+             throw new InvalidResponseException('Invalid or empty response from MyData API');
+         }
 
             return $response ;
         } catch (GuzzleException $e) {

--- a/src/Http/RequestBookInfo.php
+++ b/src/Http/RequestBookInfo.php
@@ -54,9 +54,6 @@ abstract class RequestBookInfo extends MyDataRequest
         // Get the response XML
         $responseXML = $this->get($query)->getBody()->getContents();
 
-        if (empty($responseXML)) {
-            throw new MyDataException('Invalid response from MyData API');
-        }
         // Parse the response XML
         $reader = new BookInfoReader();
         $bookInfo = $reader->parseXML($responseXML);

--- a/src/Http/RequestBookInfo.php
+++ b/src/Http/RequestBookInfo.php
@@ -52,9 +52,11 @@ abstract class RequestBookInfo extends MyDataRequest
         $query = array_filter($query);
 
         // Get the response XML
-        $response = $this->get($query);
-        $responseXML = $response->getBody()->getContents();
+        $responseXML = $this->get($query)->getBody()->getContents();
 
+        if (empty($responseXML)) {
+            throw new MyDataException('Invalid response from MyData API');
+        }
         // Parse the response XML
         $reader = new BookInfoReader();
         $bookInfo = $reader->parseXML($responseXML);

--- a/src/Http/RequestVatInfo.php
+++ b/src/Http/RequestVatInfo.php
@@ -54,10 +54,6 @@ class RequestVatInfo extends MyDataRequest
         // Get the response XML
         $responseXML = $this->get($query)->getBody()->getContents();
         
-        if (empty($responseXML)) {
-            throw new MyDataException('Invalid response from MyData API');
-        }
-
         // Parse the response XML
         $reader = new VatInfoReader();
         $vatInfo = $reader->parseXML($responseXML);

--- a/src/Http/RequestVatInfo.php
+++ b/src/Http/RequestVatInfo.php
@@ -52,8 +52,11 @@ class RequestVatInfo extends MyDataRequest
         ], fn($value) => $value !== null);
 
         // Get the response XML
-        $response = $this->get($query);
-        $responseXML = $response->getBody()->getContents();
+        $responseXML = $this->get($query)->getBody()->getContents();
+        
+        if (empty($responseXML)) {
+            throw new MyDataException('Invalid response from MyData API');
+        }
 
         // Parse the response XML
         $reader = new VatInfoReader();

--- a/src/Models/InvoiceDetails.php
+++ b/src/Models/InvoiceDetails.php
@@ -873,7 +873,7 @@ class InvoiceDetails extends Type
     {
         if (($key === 'expensesClassification' || $key === 'incomeClassification') && !is_array($value)) {
             if (!($value instanceof IncomeClassification || $value instanceof ExpensesClassification)) {
-                throw new InvalidArgumentException("Invalid classification type.");
+                throw new \InvalidArgumentException("Invalid classification type.");
             }
             return $this->push($key, $value);
         }

--- a/src/Models/InvoiceDetails.php
+++ b/src/Models/InvoiceDetails.php
@@ -867,10 +867,14 @@ class InvoiceDetails extends Type
     {
         return $this->set('notVAT195', $notVAT195);
     }
+    
 
     public function set($key, $value): static
     {
         if (($key === 'expensesClassification' || $key === 'incomeClassification') && !is_array($value)) {
+            if (!($value instanceof IncomeClassification || $value instanceof ExpensesClassification)) {
+                throw new InvalidArgumentException("Invalid classification type.");
+            }
             return $this->push($key, $value);
         }
 

--- a/src/Models/InvoiceSummary.php
+++ b/src/Models/InvoiceSummary.php
@@ -115,7 +115,7 @@ class InvoiceSummary extends Type
      * @param  float  $amount  Το σύνολο των προκαταβληθέντων φόρων που δεν επηρεάζουν τη συνολική αξία (πληρωτέο ποσό) του παραστατικού.
      * @return $this
      */
-    public function setTotalInformationTaxAmount(float $amount): static
+    public function setTotalInformationalTaxAmount(float $amount): static
     {
         $this->totalInformationalTaxAmount = $amount;
         return $this;

--- a/src/Models/Type.php
+++ b/src/Models/Type.php
@@ -6,10 +6,10 @@ use BackedEnum;
 
 abstract class Type
 {
-    protected array $attributes    = [];
-    protected array $expectedOrder = [];
-    protected array $casts         = [];
-    private   array $enumCache     = [];
+    protected array      $attributes    = [];
+    protected array      $expectedOrder = [];
+    protected array      $casts         = [];
+    private static array $enumCache     = [];
 
     public function __construct(array $attributes = [])
     {
@@ -97,19 +97,19 @@ abstract class Type
     {
         foreach ($attributes as $key => $value) {
             $set = 'set'.str_replace('_', '', ucwords($key, '_'));
-            
+
             if (is_object($value) || !method_exists($this, $set)) {
                 $this->attributes[$key] = $value;
                 continue;
             }
-            
+
             $cast = $this->getCast($key);
-            
+
             if ($cast === null || !is_subclass_of($cast, Type::class)) {
                 $this->set($key, $value);
                 continue;
             }
-            
+
             if (is_subclass_of($cast, TypeArray::class)) {
                 $this->$set(array_shift($value));
                 continue;
@@ -140,17 +140,17 @@ abstract class Type
         $cast = $this->casts[$name] ?? null;
 
         // Return false if $cast is null or directly return the cached value
-        if ($cast === null || isset($this->enumCache[$cast])) {
-            return $this->enumCache[$cast] ?? false;
+        if ($cast === null || isset(self::$enumCache[$cast])) {
+            return self::$enumCache[$cast] ?? false;
         }
 
         // Check if the class exists and implements BackedEnum
         if (!class_exists($cast) || !is_subclass_of($cast, BackedEnum::class)) {
-            return $this->enumCache[$cast] = false;
+            return self::$enumCache[$cast] = false;
         }
 
         // Cache and return the result
-        return $this->enumCache[$cast] = true;
+        return self::$enumCache[$cast] = true;
     }
 
     /**

--- a/src/Models/Type.php
+++ b/src/Models/Type.php
@@ -2,7 +2,7 @@
 
 namespace Firebed\AadeMyData\Models;
 
-use ReflectionClass;
+use BackedEnum;
 
 abstract class Type
 {
@@ -139,27 +139,18 @@ abstract class Type
     {
         $cast = $this->casts[$name] ?? null;
 
-        if ($cast === null) {
-            return false;
+        // Return false if $cast is null or directly return the cached value
+        if ($cast === null || isset($this->enumCache[$cast])) {
+            return $this->enumCache[$cast] ?? false;
         }
 
-        // Έλεγχος αν το αποτέλεσμα είναι ήδη στην cache
-        if (isset($this->enumCache[$cast])) {
-            return $this->enumCache[$cast];
+        // Check if the class exists and implements BackedEnum
+        if (!class_exists($cast) || !is_subclass_of($cast, BackedEnum::class)) {
+            return $this->enumCache[$cast] = false;
         }
 
-        // Έλεγχος αν η κλάση υπάρχει
-        if (!class_exists($cast)) {
-            $this->enumCache[$cast] = false;
-            return false;
-        }
-
-       
-        $reflection = new ReflectionClass($cast);
-        $isEnum = $reflection->isEnum();
-        // Αποθήκευση του αποτελέσματος στην cache
-        $this->enumCache[$cast] = $isEnum;
-        return $isEnum;
+        // Cache and return the result
+        return $this->enumCache[$cast] = true;
     }
 
     /**

--- a/src/Models/Type.php
+++ b/src/Models/Type.php
@@ -154,17 +154,12 @@ abstract class Type
             return false;
         }
 
-        try {
-            $reflection = new ReflectionClass($cast);
-            $isEnum = $reflection->isEnum();
-            // Αποθήκευση του αποτελέσματος στην cache
-            $this->enumCache[$cast] = $isEnum;
-            return $isEnum;
-        } catch (ReflectionException $e) {
-            // Σε περίπτωση εξαίρεσης, αποθηκεύουμε false στην cache
-            $this->enumCache[$cast] = false;
-            return false;
-        }
+       
+        $reflection = new ReflectionClass($cast);
+        $isEnum = $reflection->isEnum();
+        // Αποθήκευση του αποτελέσματος στην cache
+        $this->enumCache[$cast] = $isEnum;
+        return $isEnum;
     }
 
     /**

--- a/tests/EnumCacheTest.php
+++ b/tests/EnumCacheTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests;
+
+use Firebed\AadeMyData\Enums\IncomeClassificationType;
+use Firebed\AadeMyData\Models\IncomeClassification;
+use Firebed\AadeMyData\Models\InvoiceDetails;
+use PHPUnit\Framework\TestCase;
+use Firebed\AadeMyData\Models\Type;
+use ReflectionClass;
+
+class EnumCacheTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // Reset the static enum cache after each test
+        $reflection = new ReflectionClass(Type::class);
+        $enumCacheProperty = $reflection->getProperty('enumCache');
+        $enumCacheProperty->setValue([]);
+    }
+
+    public function test_enum_cache_is_updated_after_check()
+    {
+        $type = new IncomeClassification();
+
+        // Initially, the cache should be empty
+        $this->assertEmpty($this->getEnumCache());
+
+        // Call isEnum to populate the cache
+        $this->assertTrue($type->isEnum('classificationType'));
+
+        // After checking, the cache should have the 'classificationType' enum entry
+        $enumCache = $this->getEnumCache();
+        $this->assertArrayHasKey(IncomeClassificationType::class, $enumCache);
+        $this->assertTrue($enumCache[IncomeClassificationType::class]);
+    }
+
+    public function test_enum_cache_handles_non_casted_enums_correctly()
+    {
+        $type = new IncomeClassification();
+
+        // Initially, the cache should be empty
+        $this->assertEmpty($this->getEnumCache());
+
+        // Call isEnum with a non-existent cast
+        $this->assertFalse($type->isEnum('nonexistent'));
+
+        // The cache should not contain the nonexistent key
+        $enumCache = $this->getEnumCache();
+        $this->assertArrayNotHasKey('invalid', $enumCache);
+    }
+
+    public function test_enum_cache_handles_non_enum_correctly()
+    {
+        $row = new InvoiceDetails();
+
+        // Initially, the cache should be empty
+        $this->assertEmpty($this->getEnumCache());
+
+        // Call isEnum with a non-enum type
+        $this->assertFalse($row->isEnum('incomeClassification'));
+        
+        // The cache should have false for the nonexistent key, because
+        // IncomeClassification although cast, it is a Type and not an enum.
+        $enumCache = $this->getEnumCache();
+        $this->assertFalse($enumCache[IncomeClassification::class]);
+    }
+    
+    private function getEnumCache(): array
+    {
+        $reflection = new ReflectionClass(Type::class);
+        $enumCacheProperty = $reflection->getProperty('enumCache');
+        return $enumCacheProperty->getValue();
+    }
+}

--- a/tests/EnumCacheTest.php
+++ b/tests/EnumCacheTest.php
@@ -13,7 +13,7 @@ class EnumCacheTest extends TestCase
 {
     protected function setUp(): void
     {
-        // Reset the static enum cache after each test
+        // Reset the static enum cache before each test
         $reflection = new ReflectionClass(Type::class);
         $enumCacheProperty = $reflection->getProperty('enumCache');
         $enumCacheProperty->setValue([]);


### PR DESCRIPTION
1. Although there are several checks during the creation of the XML, it would be good to perform a check for emptiness before parsing the XML
2. Cleaner code ($request)