### PR TITLE
Update WithheldPercentCategory.php

### DIFF
--- a/src/Enums/WithheldPercentCategory.php
+++ b/src/Enums/WithheldPercentCategory.php
@@ -140,7 +140,6 @@ enum WithheldPercentCategory: int
     public function affectsTotalGrossValue(): bool
     {
         return !in_array($this, [
-            self::TAX_8,
             self::TAX_9,
             self::TAX_10,
         ]);


### PR DESCRIPTION
Ο `Προκαταβλητέος Φόρος Αρχιτεκτόνων και Μηχανικών επί Συμβατικών Αμοιβών, για Εκπόνηση Μελετών και Σχεδίων 4%` επηρεάζει το πληρωτέο του παραστατικού (totalGrossValue) και ως εκ τούτο πρέπει να αφαιρείται.