### PR TITLE
feat: Add tax classification validation for tax types and categories

### DIFF
--- a/src/Enums/TaxType.php
+++ b/src/Enums/TaxType.php
@@ -2,10 +2,12 @@
 
 namespace Firebed\AadeMyData\Enums;
 
+use BackedEnum;
+
 enum TaxType: int
 {
     use HasLabels;
-    
+
     /**
      * Παρακρατούμενος Φόρος
      */
@@ -20,20 +22,83 @@ enum TaxType: int
      * Λοιποί Φόροι
      */
     case TYPE_3 = 3;
-    
+
     /**
      * Χαρτόσημο
      */
     case TYPE_4 = 4;
-    
+
     /**
      * Κρατήσεις
      */
     case TYPE_5 = 5;
 
+    /**
+     * Checks if a given tax category exists for a specific tax type.
+     *
+     * This function validates whether a tax category is valid for a given tax type. Each tax type
+     * corresponds to a specific set of tax categories, represented by enums. If the tax category
+     * is valid for the tax type, the function returns `true`; otherwise, it returns `false`.
+     *
+     * @param  TaxType|int  $taxType  The tax type to check. Can be an instance of `TaxType` or an integer.
+     * @param  BackedEnum|int|null  $taxCategory  The tax category to validate. Can be a tax category enum, an integer or `null` (for tax types that don't require a category).
+     * @return bool Returns `true` if the tax category exists for the given tax type, otherwise `false`.
+     *
+     * @example
+     * Check if tax category 1 exists for TaxType::TYPE_1
+     * taxCategoryExists(TaxType::TYPE_1, 1); // Returns true if valid, false otherwise
+     * taxCategoryExists(TaxType::TYPE_1, WithheldPercentCategory::TAX_1); // Returns true if valid, false otherwise
+     *
+     * Check if tax category is valid for TaxType::TYPE_5 (which requires no category)
+     * taxCategoryExists(TaxType::TYPE_5, null); // Returns true
+     */
+    public static function taxCategoryExists(TaxType|int $taxType, BackedEnum|int|null $taxCategory): bool
+    {
+        if (!$taxType instanceof TaxType) {
+            $taxType = TaxType::tryFrom($taxType);
+            if ($taxType === null) {
+                return false; // Handle unexpected TaxType values
+            }
+        }
+
+        return $taxType->supportsTaxCategory($taxCategory);
+    }
+
+    /**
+     * Determines whether a given tax category is supported by the current tax type.
+     *
+     * @param  BackedEnum|int|null  $taxCategory  The tax category to check. Can be an instance of a backed enum, an integer, or null.
+     * @return bool Returns `true` if the tax category is supported for the current tax type, otherwise `false`.
+     */
+    public function supportsTaxCategory(BackedEnum|int|null $taxCategory): bool
+    {
+        // Check for null tax category to avoid tryFrom calls on null values
+        if ($taxCategory === null) {
+            return $this === self::TYPE_5;
+        }
+
+        if ($taxCategory instanceof BackedEnum) {
+            return match ($this) {
+                self::TYPE_1 => $taxCategory instanceof WithheldPercentCategory, // Παρακρατούμενοι Φόροι
+                self::TYPE_2 => $taxCategory instanceof FeesPercentCategory, // Τέλη
+                self::TYPE_3 => $taxCategory instanceof OtherTaxesPercentCategory, // Άλλοι Φόροι
+                self::TYPE_4 => $taxCategory instanceof StampCategory,
+                default => false,
+            };
+        }
+
+        return match ($this) {
+            self::TYPE_1 => WithheldPercentCategory::tryFrom($taxCategory) !== null, // Παρακρατούμενοι Φόροι
+            self::TYPE_2 => FeesPercentCategory::tryFrom($taxCategory) !== null, // Τέλη
+            self::TYPE_3 => OtherTaxesPercentCategory::tryFrom($taxCategory) !== null, // Άλλοι Φόροι
+            self::TYPE_4 => StampCategory::tryFrom($taxCategory) !== null, // Χαρτόσημο
+            default => false,
+        };
+    }
+
     public function label(): string
     {
-        return match($this) {
+        return match ($this) {
             self::TYPE_1 => "Παρακρατούμενος Φόρος",
             self::TYPE_2 => "Τέλη",
             self::TYPE_3 => "Λοιποί Φόροι",

--- a/src/Enums/TaxType.php
+++ b/src/Enums/TaxType.php
@@ -82,7 +82,7 @@ enum TaxType: int
                 self::TYPE_1 => $taxCategory instanceof WithheldPercentCategory, // Παρακρατούμενοι Φόροι
                 self::TYPE_2 => $taxCategory instanceof FeesPercentCategory, // Τέλη
                 self::TYPE_3 => $taxCategory instanceof OtherTaxesPercentCategory, // Άλλοι Φόροι
-                self::TYPE_4 => $taxCategory instanceof StampCategory,
+                self::TYPE_4 => $taxCategory instanceof StampCategory, // Χαρτόσημο
                 default => false,
             };
         }

--- a/src/Services/Classifications.php
+++ b/src/Services/Classifications.php
@@ -2,16 +2,11 @@
 
 namespace Firebed\AadeMyData\Services;
 
-use Firebed\AadeMyData\Enums\TaxType;
-use Firebed\AadeMyData\Enums\InvoiceType;
-use Firebed\AadeMyData\Enums\StampCategory;
-use Firebed\AadeMyData\Enums\FeesPercentCategory;
-use Firebed\AadeMyData\Enums\WithheldPercentCategory;
-use Firebed\AadeMyData\Enums\IncomeClassificationType;
-use Firebed\AadeMyData\Enums\ExpenseClassificationType;
-use Firebed\AadeMyData\Enums\OtherTaxesPercentCategory;
-use Firebed\AadeMyData\Enums\IncomeClassificationCategory;
 use Firebed\AadeMyData\Enums\ExpenseClassificationCategory;
+use Firebed\AadeMyData\Enums\ExpenseClassificationType;
+use Firebed\AadeMyData\Enums\IncomeClassificationCategory;
+use Firebed\AadeMyData\Enums\IncomeClassificationType;
+use Firebed\AadeMyData\Enums\InvoiceType;
 
 class Classifications
 {
@@ -84,41 +79,5 @@ class Classifications
     {
         $classifications = self::expenseClassifications($invoiceType);
         return $classifications->contains($category) && $classifications->get($category)->contains($type);
-    }
-
-    /**
-     * Checks if a given tax classification exists for a specific tax type and tax category.
-     *
-     * This function validates whether a tax category is valid for a given tax type. Each tax type
-     * corresponds to a specific set of tax categories, represented by enums. If the tax category
-     * is valid for the tax type, the function returns `true`; otherwise, it returns `false`.
-     *
-     * @param TaxType|int $taxType The tax type to check. Can be an instance of `TaxType` or an integer.
-     * @param int|null $taxCategory The tax category to validate. Can be an integer or `null` (for tax types that don't require a category).
-     * @return bool Returns `true` if the tax classification exists for the given tax type and category, otherwise `false`.
-     *
-     * @example
-     * Check if tax category 1 exists for TaxType::TYPE_1
-     * taxClassificationExists(TaxType::TYPE_1, 1); // Returns true if valid, false otherwise
-     *
-     * Check if tax category is valid for TaxType::TYPE_5 (which requires no category)
-     * taxClassificationExists(TaxType::TYPE_5, null); // Returns true
-     */
-    public static function taxClassificationExists(TaxType|int $taxType, ?int $taxCategory): bool
-    {
-        if (!$taxType instanceof TaxType) {
-            $taxType = TaxType::tryFrom($taxType);
-            if ($taxType === null) {
-                return false; // Handle unexpected TaxType values
-            }
-        }
-
-        return match ($taxType) {
-            TaxType::TYPE_1 => WithheldPercentCategory::tryFrom($taxCategory) !== null, // Παρακρατούμενοι Φόροι
-            TaxType::TYPE_2 => FeesPercentCategory::tryFrom($taxCategory) !== null, // Τέλη
-            TaxType::TYPE_3 => OtherTaxesPercentCategory::tryFrom($taxCategory) !== null, // Άλλοι Φόροι
-            TaxType::TYPE_4 => StampCategory::tryFrom($taxCategory) !== null, // Χαρτόσημο
-            TaxType::TYPE_5 => $taxCategory === null, // Κρατήσεις
-        };
     }
 }

--- a/src/Services/Classifications.php
+++ b/src/Services/Classifications.php
@@ -2,11 +2,16 @@
 
 namespace Firebed\AadeMyData\Services;
 
-use Firebed\AadeMyData\Enums\ExpenseClassificationCategory;
-use Firebed\AadeMyData\Enums\ExpenseClassificationType;
-use Firebed\AadeMyData\Enums\IncomeClassificationCategory;
-use Firebed\AadeMyData\Enums\IncomeClassificationType;
+use Firebed\AadeMyData\Enums\TaxType;
 use Firebed\AadeMyData\Enums\InvoiceType;
+use Firebed\AadeMyData\Enums\StampCategory;
+use Firebed\AadeMyData\Enums\FeesPercentCategory;
+use Firebed\AadeMyData\Enums\WithheldPercentCategory;
+use Firebed\AadeMyData\Enums\IncomeClassificationType;
+use Firebed\AadeMyData\Enums\ExpenseClassificationType;
+use Firebed\AadeMyData\Enums\OtherTaxesPercentCategory;
+use Firebed\AadeMyData\Enums\IncomeClassificationCategory;
+use Firebed\AadeMyData\Enums\ExpenseClassificationCategory;
 
 class Classifications
 {
@@ -79,5 +84,41 @@ class Classifications
     {
         $classifications = self::expenseClassifications($invoiceType);
         return $classifications->contains($category) && $classifications->get($category)->contains($type);
+    }
+
+    /**
+     * Checks if a given tax classification exists for a specific tax type and tax category.
+     *
+     * This function validates whether a tax category is valid for a given tax type. Each tax type
+     * corresponds to a specific set of tax categories, represented by enums. If the tax category
+     * is valid for the tax type, the function returns `true`; otherwise, it returns `false`.
+     *
+     * @param TaxType|int $taxType The tax type to check. Can be an instance of `TaxType` or an integer.
+     * @param int|null $taxCategory The tax category to validate. Can be an integer or `null` (for tax types that don't require a category).
+     * @return bool Returns `true` if the tax classification exists for the given tax type and category, otherwise `false`.
+     *
+     * @example
+     * Check if tax category 1 exists for TaxType::TYPE_1
+     * taxClassificationExists(TaxType::TYPE_1, 1); // Returns true if valid, false otherwise
+     *
+     * Check if tax category is valid for TaxType::TYPE_5 (which requires no category)
+     * taxClassificationExists(TaxType::TYPE_5, null); // Returns true
+     */
+    public static function taxClassificationExists(TaxType|int $taxType, ?int $taxCategory): bool
+    {
+        if (!$taxType instanceof TaxType) {
+            $taxType = TaxType::tryFrom($taxType);
+            if ($taxType === null) {
+                return false; // Handle unexpected TaxType values
+            }
+        }
+
+        return match ($taxType) {
+            TaxType::TYPE_1 => WithheldPercentCategory::tryFrom($taxCategory) !== null, // Παρακρατούμενοι Φόροι
+            TaxType::TYPE_2 => FeesPercentCategory::tryFrom($taxCategory) !== null, // Τέλη
+            TaxType::TYPE_3 => OtherTaxesPercentCategory::tryFrom($taxCategory) !== null, // Άλλοι Φόροι
+            TaxType::TYPE_4 => StampCategory::tryFrom($taxCategory) !== null, // Χαρτόσημο
+            TaxType::TYPE_5 => $taxCategory === null, // Κρατήσεις
+        };
     }
 }

--- a/tests/TaxTypeTest.php
+++ b/tests/TaxTypeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests;
+
+use Firebed\AadeMyData\Enums\FeesPercentCategory;
+use Firebed\AadeMyData\Enums\TaxType;
+use Firebed\AadeMyData\Enums\WithheldPercentCategory;
+use PHPUnit\Framework\TestCase;
+
+class TaxTypeTest extends TestCase
+{
+    public function test_tax_combination(): void
+    {
+        $this->assertTrue(TaxType::taxCategoryExists(TaxType::TYPE_1, WithheldPercentCategory::TAX_1->value));
+        $this->assertTrue(TaxType::taxCategoryExists(TaxType::TYPE_1, WithheldPercentCategory::TAX_1));
+        $this->assertTrue(TaxType::taxCategoryExists(TaxType::TYPE_5, null));
+        $this->assertFalse(TaxType::taxCategoryExists(TaxType::TYPE_1, FeesPercentCategory::TYPE_22->value));
+        $this->assertFalse(TaxType::taxCategoryExists(TaxType::TYPE_1, FeesPercentCategory::TYPE_22));
+        $this->assertFalse(TaxType::taxCategoryExists(TaxType::TYPE_1, null));
+
+        $this->assertTrue(TaxType::TYPE_1->supportsTaxCategory(WithheldPercentCategory::TAX_1->value));
+        $this->assertTrue(TaxType::TYPE_1->supportsTaxCategory(WithheldPercentCategory::TAX_1));
+        $this->assertTrue(TaxType::TYPE_5->supportsTaxCategory(null));
+        $this->assertFalse(TaxType::TYPE_1->supportsTaxCategory(FeesPercentCategory::TYPE_22->value));
+        $this->assertFalse(TaxType::TYPE_1->supportsTaxCategory(FeesPercentCategory::TYPE_22));
+        $this->assertFalse(TaxType::TYPE_1->supportsTaxCategory(null));
+
+        $this->assertFalse(TaxType::taxCategoryExists(999, 1));
+    }
+}


### PR DESCRIPTION
**What this PR does:**
- Introduces a new method `taxClassificationExists` to validate whether a tax category is valid for a given tax type.
- Supports both `TaxType` enum instances and integer values for tax types.
- Ensures proper validation of tax categories for each tax type, improving data integrity and error handling.

**Why this is needed:**
- This functionality is essential for ensuring that tax classifications are correctly validated, preventing errors in tax-related calculations and reporting.

**Supported Tax Types and Categories:**
- `TaxType::TYPE_1`: Validates against `WithheldPercentCategory`.
- `TaxType::TYPE_2`: Validates against `FeesPercentCategory`.
- `TaxType::TYPE_3`: Validates against `OtherTaxesPercentCategory`.
- `TaxType::TYPE_4`: Validates against `StampCategory`.
- `TaxType::TYPE_5`: Requires no tax category (`null`).

**Example Usage:**
```php
// Check if tax category 1 exists for TaxType::TYPE_1
taxClassificationExists(TaxType::TYPE_1, 1); // Returns true if valid, false otherwise

// Check if tax category is valid for TaxType::TYPE_5 (which requires no category)
taxClassificationExists(TaxType::TYPE_5, null); // Returns true