### PR TITLE
Update examples.md with correct Request/Response XML functions

### DIFF
--- a/docs/invoices/examples.md
+++ b/docs/invoices/examples.md
@@ -45,10 +45,14 @@ try {
     // Ανάκτηση του XML αίτησης
     $requestDom = $request->getRequestDom();
     $requestXml = $requestDom->saveXML();
+    // ή
+    $requestXml = $request->getRequestXml();
         
     // Ανάκτηση του XML απάντησης
-    $responseDom = $request->getRequestDom();
+    $responseDom = $request->getResponseDom();
     $responseXml = $responseDom->saveXML();
+    // ή
+    $requestXml = $request->getResponseXML();
     
     // Ανάκτηση και εξέταση της πρώτης απάντησης
     $response = $responses->first();    


### PR DESCRIPTION
This PR updates `examples.md` documentation to reflect the correct function names:
- `getRequestXml()`
- `getResponseXml()`

These changes replace incorrect references, ensuring consistency with the current `Firebed\AadeMyData\Http\Traits\HasRequestDom` and `HasResponseDom` available public functions.